### PR TITLE
💄 태블릿에서 레시피의 재료가 많을 경우, 전부 표시되지 않는 버그 수정

### DIFF
--- a/components/explore/RecipeCard.tsx
+++ b/components/explore/RecipeCard.tsx
@@ -28,7 +28,7 @@ export const RecipeCard = React.memo(({ keyword, ...recipe }: RecipeCardProps) =
       href={`/recipeDetail?recipe=${JSON.stringify({ ...recipe, isSaved })}`}
       className="flex-1">
       <View
-        className="w-full overflow-hidden rounded-xl"
+        className="flex-1 overflow-hidden rounded-xl"
         style={{
           shadowOffset: { width: 0, height: 2 },
           shadowOpacity: 0.5,


### PR DESCRIPTION
# 주요변경점
- `w-full` -> `flex-1 w-full`
> width는 가득차도록 고정하면서, height이 자유롭게 늘어날 수 있도록 조정함. 기존 화면에서는 의도대로 동작하는 것을 확인했지만, 태블릿이 없어 버그가 제대로 고쳐졌는지는 확인이 필요함. 추후에 태블릿 가상 머신을 다운받아 확인 예정.